### PR TITLE
dealing with non-alphanumeric characters

### DIFF
--- a/importNewCardDeck.js
+++ b/importNewCardDeck.js
@@ -23,6 +23,7 @@ async function importDeck(imagespath, deckname, backimage, nameback) {
     let cardName;
     cards.forEach(c => {
         cardName = strip_extension(basename(c, '/'));
+        cardName = decodeURIComponent(cardName)
         toCreate.push({ name: cardName, origin: deck.id, back: { img: backimage, name: nameback }, faces: [{ img: c, name: cardName }], face: 0 });
     });
     deck.createEmbeddedDocuments("Card", toCreate);


### PR DESCRIPTION
I noticed that the card names were URI-encoded, so for example spaces were replaced with %20. I added `cardName = decodeURIComponent(cardName)` to line 20 to fix this.